### PR TITLE
 Fix missing drawille-braille-reverse-table

### DIFF
--- a/drawille.el
+++ b/drawille.el
@@ -82,6 +82,9 @@
            into offsets finally return
            (apply '+ drawille-braille-unicode-offset offsets)))
 
+(defconst drawille-braille-reverse-table [7 6 5 3 1 4 2 0]
+  "Table to convert braille character to coordinates.")
+
 (defun drawille-char-to-vector (char)
   "Translate a braille CHAR to a corresponding vector."
   (cl-loop with char-offset = (- char drawille-braille-unicode-offset)


### PR DESCRIPTION
Seems like 5fd8246de00bdc9e522973cc7b63f9cb839ccf43 mistakenly removed the `drawille-braille-reverse-table`.  Consequently, all draw functions (namely, non-string drawing) that rely `drawille-char-to-vector` were broken.